### PR TITLE
working

### DIFF
--- a/src/_api/get-history.ts
+++ b/src/_api/get-history.ts
@@ -1,9 +1,11 @@
 import { BASE_URL, HISTORY_PATH } from '@/src/_db/mock-api/constants';
 import { IRacerHistory } from '@/src/_types';
 
+export const getRiderHistoryRequestUrl = (id: number) => `${BASE_URL}${HISTORY_PATH}?racerId=${id}`;
+
 export const getRiderHistory = async (id: number) => {
   try {
-    const response = await fetch(`${BASE_URL}${HISTORY_PATH}?racerId=${id}`);
+    const response = await fetch(getRiderHistoryRequestUrl(id));
     const parsedResponse: IRacerHistory[] = await response.json();
     return parsedResponse[0].results;
   } catch {

--- a/src/_api/get-rider.ts
+++ b/src/_api/get-rider.ts
@@ -2,9 +2,11 @@ import { BASE_URL, RACERS_PATH } from '@/src/_db/mock-api/constants';
 import { IRiderInfo } from '@/src/_types';
 import { DEFAULT_RIDER_NOT_FOUND } from '../global-constants';
 
+export const getSingleRiderRequestUrl = (id: number) => `${BASE_URL}${RACERS_PATH}?id=${id}`;
+
 export const getSingleRider = async (id: number): Promise<IRiderInfo | null> => {
   try {
-    const response = await fetch(`${BASE_URL}${RACERS_PATH}?id=${id}`);
+    const response = await fetch(getSingleRiderRequestUrl(id));
     const parsedResponse: IRiderInfo[] = await response.json();
     return parsedResponse[0];
   } catch (error) {

--- a/src/_components/Sample/Sample.tsx
+++ b/src/_components/Sample/Sample.tsx
@@ -3,15 +3,19 @@
 import React from 'react';
 import { Text } from '@mantine/core';
 import { getRiderHistory } from '@/src/_api/get-history';
+import { getSingleRider } from '@/src/_api/get-rider';
 
 export default function Sample() {
   const [thing, setThing] = React.useState<any>(null);
+  const [secondThing, setSecondThing] = React.useState<any>(null);
 
   React.useEffect(() => {
     const fetchSomething = async () => {
-      const response = await getRiderHistory(1);
-      console.log(response);
-      setThing('Done');
+      const historyResponse = await getRiderHistory(1);
+      const riderResponse = await getSingleRider(1);
+
+      setThing(`${historyResponse[0].year}`);
+      setSecondThing(`${riderResponse?.name.first}`);
     };
     fetchSomething();
   });
@@ -19,5 +23,10 @@ export default function Sample() {
   if (!thing) {
     return <Text>Loading</Text>;
   }
-  return <Text>{thing}</Text>;
+  return (
+    <>
+      <Text>{thing}</Text>
+      <Text>{secondThing}</Text>
+    </>
+  );
 }

--- a/src/_components/Sample/__tests__/Sample.test.tsx
+++ b/src/_components/Sample/__tests__/Sample.test.tsx
@@ -1,13 +1,15 @@
+import { getRiderHistoryRequestUrl } from '@/src/_api/get-history';
+import { getSingleRiderRequestUrl } from '@/src/_api/get-rider';
 import { mockRacingHistory } from '@/src/_db/mock-data/mock-race-history';
 import { mockRider } from '@/src/_db/mock-data/mock-racer';
 import { mockMultiGlobalFetch } from '@/src/test-helpers';
 import { render, screen } from '@/test-utils';
 import Sample from '../Sample';
 
-const firstExpectedURL = 'http://localhost:8000/history?racerId=1';
+const firstExpectedURL = getRiderHistoryRequestUrl(1);
 const firstMockResponse = [mockRacingHistory];
 
-const secondExpectedURL = 'http://localhost:8000/racers?id=1';
+const secondExpectedURL = getSingleRiderRequestUrl(1);
 const secondMockResponse = [mockRider];
 
 afterEach(() => {

--- a/src/_components/Sample/__tests__/Sample.test.tsx
+++ b/src/_components/Sample/__tests__/Sample.test.tsx
@@ -1,12 +1,41 @@
+import { mockRacingHistory } from '@/src/_db/mock-data/mock-race-history';
+import { mockRider } from '@/src/_db/mock-data/mock-racer';
+import { mockMultiGlobalFetch } from '@/src/test-helpers';
 import { render, screen } from '@/test-utils';
 import Sample from '../Sample';
+
+const firstExpectedURL = 'http://localhost:8000/history?racerId=1';
+const firstMockResponse = [mockRacingHistory];
+
+const secondExpectedURL = 'http://localhost:8000/racers?id=1';
+const secondMockResponse = [mockRider];
+
+afterEach(() => {
+  // restore all mocks after each test
+  jest.restoreAllMocks();
+});
+
+beforeEach(() => {
+  mockMultiGlobalFetch(
+    [firstExpectedURL, secondExpectedURL],
+    [firstMockResponse, secondMockResponse]
+  );
+});
 
 describe('Sample', () => {
   it('Renders Something', async () => {
     render(<Sample />);
+    // we should initially get a loading state
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
-    const doneElement = await screen.findByText(/Done/i);
-    expect(doneElement).toBeInTheDocument();
-    expect(screen.getByText(/Done/i)).toBeInTheDocument();
+
+    const historyResult = mockRacingHistory.results[0].year;
+    const riderResult = mockRider.name.first;
+
+    // use await screen.findByText which waits until our mock fetch returns a response
+    const histroyElement = await screen.findByText(historyResult);
+    expect(histroyElement).toBeInTheDocument();
+
+    const riderElement = await screen.findByText(riderResult);
+    expect(riderElement).toBeInTheDocument();
   });
 });

--- a/src/_components/Sample/__tests__/Sample.test.tsx
+++ b/src/_components/Sample/__tests__/Sample.test.tsx
@@ -6,11 +6,15 @@ import { mockMultiGlobalFetch } from '@/src/test-helpers';
 import { render, screen } from '@/test-utils';
 import Sample from '../Sample';
 
+// set up mock responses for global.fetch
 const firstExpectedURL = getRiderHistoryRequestUrl(1);
 const firstMockResponse = [mockRacingHistory];
 
 const secondExpectedURL = getSingleRiderRequestUrl(1);
 const secondMockResponse = [mockRider];
+
+const expectedUrls = [firstExpectedURL, secondExpectedURL];
+const expectedMockResponses = [firstMockResponse, secondMockResponse];
 
 afterEach(() => {
   // restore all mocks after each test
@@ -18,10 +22,8 @@ afterEach(() => {
 });
 
 beforeEach(() => {
-  mockMultiGlobalFetch(
-    [firstExpectedURL, secondExpectedURL],
-    [firstMockResponse, secondMockResponse]
-  );
+  // use helper to mock all fetch requests
+  mockMultiGlobalFetch(expectedUrls, expectedMockResponses);
 });
 
 describe('Sample', () => {

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,0 +1,35 @@
+/*
+ ** This function will mock the global fetch object and return however many different responses are necessary
+ */
+export const mockMultiGlobalFetch = (expectedUrls: string[], mockResponses: any[]): void => {
+  global.fetch = jest.fn((input) => {
+    const index = expectedUrls.indexOf(
+      expectedUrls.find((url: string) => url === String(input)) || ''
+    );
+    if (index < 0) {
+      console.log(
+        "Uh oh, couldn't find the expected url, make sure you have passed a URL for each expected fetch request!"
+      );
+    }
+    const mockResponse = mockResponses[index];
+    if (mockResponse.length < index + 1) {
+      console.log(
+        "Uh oh, couldn't find the expected mock response, make sure you have passed a mock response for each expected fetch request!"
+      );
+    }
+    return Promise.resolve({
+      json: () => Promise.resolve(mockResponses[index]),
+    });
+  }) as jest.Mock;
+};
+
+/*
+ ** This function will mock the global fetch object and return a mocked response.
+ */
+export const mockGlobalFetch = (mockResponse: any): void => {
+  global.fetch = jest.fn(() => {
+    return Promise.resolve({
+      json: () => Promise.resolve(mockResponse),
+    });
+  }) as jest.Mock;
+};


### PR DESCRIPTION
Created two helper functions for mocking global.fetch

The first, accepts an array of expected URLs, and the second expects an array of mock responses, then handles mocking the global.fetch object to return the expected mock result based on the input URL.

The second does the same thing, except it returns a single mock response for cases where there is only a single fetch request.