### PR TITLE
Test Coverage for RiderPage Comonent

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -12,6 +12,13 @@ const customJestConfig = {
   },
   testEnvironment: 'jest-environment-jsdom',
   collectCoverage: true,
+  collectCoverageFrom: [
+    "src/_api/**/*.ts",
+    "src/_components/**/*.tsx",
+    "src/_utility/**/*.ts",
+    "src/app/**/*.ts",
+    "!src/_db/**/*.mjs"
+  ],
   coverageDirectory: '.coverage',
 };
 

--- a/src/_api/get-rider.ts
+++ b/src/_api/get-rider.ts
@@ -14,9 +14,12 @@ export const getSingleRider = async (id: number): Promise<IRiderInfo | null> => 
   }
 };
 
+export const getRidersByTeamRequestUrl = (team: string) =>
+  `${BASE_URL}${RACERS_PATH}?currentTeam=${encodeURIComponent(team)}`;
+
 export const getRidersByTeam = async (team: string): Promise<IRiderInfo[] | null> => {
   try {
-    const response = await fetch(`${BASE_URL}${RACERS_PATH}?currentTeam=${team}`);
+    const response = await fetch(getRidersByTeamRequestUrl(team));
     return await response.json();
   } catch (error) {
     return null;

--- a/src/_components/ColorSchemeToggle/ColorSchemeToggle.tsx
+++ b/src/_components/ColorSchemeToggle/ColorSchemeToggle.tsx
@@ -7,7 +7,7 @@ export function ColorSchemeToggle() {
   const { setColorScheme } = useMantineColorScheme();
 
   return (
-    <div className={classes.colorScheme}>
+    <div className={classes.colorScheme} data-testid="color-scheme-toggle">
       <Group justify="center">
         <Button
           size="compact-sm"

--- a/src/_components/Results/server/ResultsTableServer.tsx
+++ b/src/_components/Results/server/ResultsTableServer.tsx
@@ -9,11 +9,11 @@ interface ResultsTableServerProps {
   history: IRaceYear[];
 }
 
-export default async function ResultsTableServer({ history }: ResultsTableServerProps) {
+export default function ResultsTableServer({ history }: ResultsTableServerProps) {
   const years: number[] = history?.length > 0 ? getRaceYears(history) : [];
 
   return (
-    <div className={classes.raceTableContainer}>
+    <div className={classes.raceTableContainer} data-testid="results-table-server">
       <Suspense fallback={<Loader />}>
         <ResultsTableTabs years={years} history={sortRacingDataByYear(history)} />
       </Suspense>

--- a/src/_components/Rider/server/RiderInfoServer.tsx
+++ b/src/_components/Rider/server/RiderInfoServer.tsx
@@ -8,13 +8,13 @@ interface RiderInfoServerProps {
   riderInfo: IRiderInfo;
 }
 
-export default async function RiderInfoServer({ riderInfo }: RiderInfoServerProps) {
+export default function RiderInfoServer({ riderInfo }: RiderInfoServerProps) {
   if (!riderInfo) {
     return <div>Did not work</div>;
   }
 
   return (
-    <div className={classes.riderInfoServer}>
+    <div className={classes.riderInfoServer} data-testid="rider-info-server">
       <NameHeadingServer data-testid="name-heading" {...riderInfo} />
       <InfoGrid {...riderInfo} />
     </div>

--- a/src/_components/TopNav/TopNav.tsx
+++ b/src/_components/TopNav/TopNav.tsx
@@ -7,26 +7,33 @@ import classes from './styles/top-nav.module.css';
 export default function TopNav() {
   const icon = <GoSearch />;
   return (
-    <Flex justify="right" align="center" pt={10}>
-      <Group mr={20}>
-        <Text>Home</Text>
-        <Divider orientation="vertical" />
-        <Text>Statistics</Text>
-        <Divider size="sm" orientation="vertical" />
-        <Text>Results</Text>
-        <Divider size="sm" orientation="vertical" />
-        <Text>Calendar</Text>
-        <Divider size="sm" orientation="vertical" />
-        <Text>Series</Text>
-        <Divider size="sm" orientation="vertical" />
-        <Text>Rankings</Text>
-      </Group>
-      <TextInput leftSectionPointerEvents="none" leftSection={icon} placeholder="search" />
-      <Title className={classes.title} ta="right" pl={20} pr={40}>
-        <Text inherit variant="gradient" component="span" gradient={{ from: 'blue', to: 'orange' }}>
-          ACS
-        </Text>
-      </Title>
-    </Flex>
+    <div data-testid="top-nav">
+      <Flex justify="right" align="center" pt={10}>
+        <Group mr={20}>
+          <Text>Home</Text>
+          <Divider orientation="vertical" />
+          <Text>Statistics</Text>
+          <Divider size="sm" orientation="vertical" />
+          <Text>Results</Text>
+          <Divider size="sm" orientation="vertical" />
+          <Text>Calendar</Text>
+          <Divider size="sm" orientation="vertical" />
+          <Text>Series</Text>
+          <Divider size="sm" orientation="vertical" />
+          <Text>Rankings</Text>
+        </Group>
+        <TextInput leftSectionPointerEvents="none" leftSection={icon} placeholder="search" />
+        <Title className={classes.title} ta="right" pl={20} pr={40}>
+          <Text
+            inherit
+            variant="gradient"
+            component="span"
+            gradient={{ from: 'blue', to: 'orange' }}
+          >
+            ACS
+          </Text>
+        </Title>
+      </Flex>
+    </div>
   );
 }

--- a/src/_db/mock-data/mock-racer.ts
+++ b/src/_db/mock-data/mock-racer.ts
@@ -5,7 +5,6 @@ export const TEAM_B2C2_JRA = 'B2C2 Cycling p/b JRA';
 
 export const mockRider: IRiderInfo = {
   id: 1,
-  currentTeam: 'Composting Seguros',
   wins: 4,
   topResults: [
     {

--- a/src/app/rider/[id]/__tests__/page.test.tsx
+++ b/src/app/rider/[id]/__tests__/page.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom/jest-globals';
+import '@testing-library/jest-dom';
+
+import { getRiderHistoryRequestUrl } from '@/src/_api/get-history';
+import { getRidersByTeamRequestUrl, getSingleRiderRequestUrl } from '@/src/_api/get-rider';
+import { mockRacingHistory } from '@/src/_db/mock-data/mock-race-history';
+import { mockRider, TEAM_B2C2_CONTES } from '@/src/_db/mock-data/mock-racer';
+import { mockMultiGlobalFetch } from '@/src/test-helpers';
+import { render, screen } from '@/test-utils';
+import RiderPage from '../page';
+
+// set up mock responses for global.fetch
+const firstExpectedURL = getRiderHistoryRequestUrl(1);
+const firstMockResponse = [mockRacingHistory];
+
+const secondExpectedURL = getSingleRiderRequestUrl(1);
+const secondMockResponse = [mockRider];
+
+const thirdExpectedURL = getRidersByTeamRequestUrl(TEAM_B2C2_CONTES);
+const thirdMockResponse: any[] = [];
+
+const expectedUrls = [firstExpectedURL, secondExpectedURL, thirdExpectedURL];
+const expectedMockResponses = [firstMockResponse, secondMockResponse, thirdMockResponse];
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+beforeEach(() => {
+  // use helper to mock all fetch requests
+  mockMultiGlobalFetch(expectedUrls, expectedMockResponses);
+  jest.mock('../../../../_components/Rider/client/RiderInfoTeam', () => () => (
+    <div>RiderInfoTeam</div>
+  ));
+});
+
+describe('RacerInfoServer', () => {
+  test('renders with mockRiderInfo when fetch is mocked', async () => {
+    const pageProps = {
+      params: {
+        id: 1,
+      },
+    };
+    const component = await RiderPage(pageProps);
+    render(component);
+
+    const topNavElement = await screen.findByTestId('top-nav');
+    expect(topNavElement).toBeInTheDocument();
+
+    const riderInfoElement = await screen.findByTestId('rider-info-server');
+    expect(riderInfoElement).toBeInTheDocument();
+
+    const historyElement = await screen.findByTestId('results-table-server');
+    expect(historyElement).toBeInTheDocument();
+
+    const colorSchemeElement = await screen.findByTestId('color-scheme-toggle');
+    expect(colorSchemeElement).toBeInTheDocument();
+  });
+});

--- a/src/app/rider/[id]/page.tsx
+++ b/src/app/rider/[id]/page.tsx
@@ -28,19 +28,17 @@ export default async function RiderPage({ params }: RiderPageProps) {
   riderInfo.wins = getCareerWins(history);
   riderInfo.topResults = getTopTenResults(history);
 
-  console.log('riderInfo is: ', riderInfo);
-
   return (
     <>
       <div className={classes.infoWrap}>
         <TopNav />
         <Suspense fallback={<Loader />}>
-          <RiderInfoServer data-testid="rider-info-server" riderInfo={riderInfo} />
+          <RiderInfoServer riderInfo={riderInfo} />
         </Suspense>
       </div>
       <div className={classes.resultsWrap}>
         <Group pb="50px">
-          <ResultsTableServer data-testid="results-table-server" history={history} />
+          <ResultsTableServer history={history} />
         </Group>
         <ColorSchemeToggle />
       </div>

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -11,12 +11,32 @@ export const mockMultiGlobalFetch = (expectedUrls: string[], mockResponses: any[
       console.log(
         "Uh oh, couldn't find the expected url, make sure you have passed a URL for each expected fetch request!"
       );
+      const slush = {
+        input,
+        expectedUrls,
+        mockResponses,
+        index,
+      };
+      console.log('slush: ', slush);
+      throw new Error(
+        "Uh oh, couldn't find the expected url, make sure you have passed a URL for each expected fetch request!"
+      );
     }
 
     const mockResponse = mockResponses[index];
 
     if (!mockResponse) {
       console.log(
+        "Uh oh, couldn't find the expected mock response, make sure you have passed a mock response for each expected fetch request!"
+      );
+      const slush = {
+        input,
+        expectedUrls,
+        mockResponses,
+        index,
+      };
+      console.log('slush: ', slush);
+      throw new Error(
         "Uh oh, couldn't find the expected mock response, make sure you have passed a mock response for each expected fetch request!"
       );
     }


### PR DESCRIPTION
- Created test for RiderPage component
- Update jest.config.cjs: Added the collectCoverageFrom field to be intentional about which directories to check for test coverage
- Standardized API request URLs to be pulled into tests for mocking
- Made RiderInfoServer and ResultsTableServer non-async components so they can render correctly in the RiderPage test. Since these do not make network requests anymore it works. If I need them to make network requests in the future I may need to make them client components.
- Updated logs in MockMultiGlobalFetch to include a slush object with all relevant data